### PR TITLE
Add Cold Boot action to emulator context menus

### DIFF
--- a/AvdBuddy/ContentView.swift
+++ b/AvdBuddy/ContentView.swift
@@ -340,6 +340,15 @@ struct ContentView: View {
                 }
             ),
             CardMenuAction(
+                title: "Cold Boot",
+                systemImage: nil,
+                isDestructive: false,
+                isEnabled: !manager.isRunning(emulator) && !manager.isBusy && !manager.isDeleting(emulator),
+                handler: {
+                    launch(emulator, coldBoot: true)
+                }
+            ),
+            CardMenuAction(
                 title: "Stop",
                 systemImage: nil,
                 isDestructive: false,
@@ -416,7 +425,7 @@ struct ContentView: View {
         ]
     }
 
-    private func launch(_ emulator: EmulatorInstance) {
+    private func launch(_ emulator: EmulatorInstance, coldBoot: Bool = false) {
         guard !manager.isRunning(emulator) else {
             manager.statusMessage = "\(emulator.name) is already running."
             return
@@ -426,7 +435,7 @@ struct ContentView: View {
             isPresentingSDKSetup = true
             return
         }
-        Task { await manager.launch(emulator) }
+        Task { await manager.launch(emulator, coldBoot: coldBoot) }
     }
 
     private func stop(_ emulator: EmulatorInstance) {

--- a/AvdBuddy/Services/EmulatorManager.swift
+++ b/AvdBuddy/Services/EmulatorManager.swift
@@ -389,16 +389,16 @@ final class EmulatorManager: ObservableObject {
         createCancellationFlag?.cancel()
     }
 
-    func launch(_ emulator: EmulatorInstance) async {
+    func launch(_ emulator: EmulatorInstance, coldBoot: Bool = false) async {
         guard !isBusy else { return }
         guard !deletingEmulatorNames.contains(emulator.name) else { return }
         isBusy = true
         defer { isBusy = false }
 
         do {
-            try launchEmulator(named: emulator.name)
+            try launchEmulator(named: emulator.name, coldBoot: coldBoot)
             runningEmulatorNames.insert(emulator.name)
-            statusMessage = "Launched \(emulator.name)."
+            statusMessage = coldBoot ? "Cold booted \(emulator.name)." : "Launched \(emulator.name)."
         } catch {
             statusMessage = "Launch failed: \(error.localizedDescription)"
         }
@@ -812,10 +812,14 @@ final class EmulatorManager: ObservableObject {
         }
     }
 
-    private func launchEmulator(named avdName: String) throws {
+    private func launchEmulator(named avdName: String, coldBoot: Bool = false) throws {
         let toolchain = try requireToolchain(for: "Launching an emulator")
         let emulatorBinary = toolchain.emulator
         var arguments = ["-avd", avdName]
+
+        if coldBoot {
+            arguments.append("-no-snapshot-load")
+        }
 
         if let launchSkin = launchSkinConfiguration(forAVDNamed: avdName, sdkRootPath: toolchain.sdkPath) {
             arguments.append(contentsOf: ["-skindir", launchSkin.directoryPath, "-skin", launchSkin.skinName])

--- a/AvdBuddyTests/EmulatorManagerTests.swift
+++ b/AvdBuddyTests/EmulatorManagerTests.swift
@@ -478,6 +478,28 @@ struct EmulatorManagerTests {
     }
 
     @Test @MainActor
+    func coldBootsEmulatorWithoutLoadingSnapshot() async throws {
+        let sdkRoot = try temporarySDKRoot()
+        defer { try? FileManager().removeItem(at: sdkRoot) }
+        try createSDKToolchainFixture(at: sdkRoot)
+
+        let runner = MockRunner()
+        let manager = EmulatorManager(
+            runner: runner,
+            fileManager: FileManager(),
+            sdkPath: sdkRoot.path
+        )
+
+        await manager.launch(EmulatorInstance(id: "a", name: "Pixel_API_24", apiLevel: 24), coldBoot: true)
+
+        #expect(runner.commands.count == 1)
+        #expect(runner.commands[0].executable == "\(sdkRoot.path)/emulator/emulator")
+        #expect(runner.commands[0].arguments == ["-avd", "Pixel_API_24", "-no-snapshot-load"])
+        #expect(runner.commands[0].waitForExit == false)
+        #expect(manager.statusMessage == "Cold booted Pixel_API_24.")
+    }
+
+    @Test @MainActor
     func launchesEmulatorWithDeviceSkinWhenFrameEnabled() async throws {
         let sdkRoot = try temporarySDKRoot()
         defer { try? FileManager().removeItem(at: sdkRoot) }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added Start and Stop actions to emulator context menus, enabling each action based on the emulator's current running state.
+- Added a Cold Boot action to emulator context menus that launches the selected AVD without loading a snapshot.
 
 ## [0.5.0] - 2026-03-04
 


### PR DESCRIPTION
## Summary

Adds a **Cold Boot** action to each emulator's context menu so you can launch an AVD without restoring a snapshot.

- Passes `-no-snapshot-load` to the emulator binary
- Enabled only when the emulator is stopped, matching the existing Start action
- Shows a distinct status message (`Cold booted <name>.`)
- Covered by a unit test that asserts the extra emulator argument

`scripts/runMac` local-only changes are not included.

## Test plan

- [ ] Cold Boot is available in an emulator card's context menu
- [ ] Cold Boot is disabled while the emulator is running, busy, or being deleted
- [ ] Cold Boot launches a stopped AVD and skips the last snapshot
- [ ] Regular Start still launches with a snapshot when one exists
- [ ] Status message reads `Cold booted <name>.` after a successful cold boot